### PR TITLE
Extract the handling of unauthorized out of the oauth2-wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ clj-oauth2 wraps clj-http for accessing protected resources.
 
  ; Set up the wrappers
  (def app 
-    (-> handler 
+    (-> handler
         (wrap-oauth2 force-com-oauth2)
         wrap-session 
         wrap-keyword-params
@@ -102,6 +102,22 @@ clj-oauth2 wraps clj-http for accessing protected resources.
    (let [port (Integer/parseInt (get (System/getenv) "PORT" "8080"))]
         (jetty/run-jetty app {:port port})))
 ```
+
+If you want to redirect unauthenticated requests to the authorization server, you also need to add the following:
+
+```
+; Set up the wrappers
+ (def app
+    (-> handler
+        (wrap-redirect-unauthenticated force-com-oauth2)
+        (wrap-oauth2 force-com-oauth2)
+        wrap-session
+        wrap-keyword-params
+        wrap-params))
+```
+
+Note that you should not redirect API calls, e.g calls with accept header application/json. In that case you
+may want to implement your own middleware for unathenticated requests.
 
 ## Contributors
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.telenordigital.data-insights/clj-oauth2 "0.5.8"
+(defproject com.telenordigital.data-insights/clj-oauth2 "0.6.0"
   :description "clj-http and ring middlewares for OAuth 2.0"
   :url "https://github.com/comoyo/clj-oauth2"
   :dependencies [[org.clojure/clojure "1.7.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject com.telenordigital.data-insights/clj-oauth2 "0.5.7"
+(defproject com.telenordigital.data-insights/clj-oauth2 "0.5.8"
   :description "clj-http and ring middlewares for OAuth 2.0"
-  :url "https://github.com/13o6/clj-oauth2"
+  :url "https://github.com/comoyo/clj-oauth2"
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [cheshire "5.5.0"]
                  [clj-http "1.1.0"]

--- a/src/clj_oauth2/client.clj
+++ b/src/clj_oauth2/client.clj
@@ -9,11 +9,6 @@
   (:import [clj_oauth2 OAuth2Exception OAuth2StateMismatchException]
            [org.apache.commons.codec.binary Base64]))
 
-;; Random mixed case alphanumeric
-(defn- random-string [length]
-  (let [ascii-codes (concat (range 48 58) (range 65 91) (range 97 123))]
-    (apply str (repeatedly length #(char (rand-nth ascii-codes))))))
-
 (defn make-auth-request
   [{:keys [authorization-uri client-id redirect-uri scope access-type]}
    & [state]]
@@ -27,15 +22,6 @@
                 scope       (assoc :scope (str/join " " scope)))]
     {:uri (str (uri/make (assoc uri :query query)))
      :scope scope :state state}))
-
-(defn redirect-to-authentication-server [_ request oauth2-params]
-  "Returns a redirect to the authentication server"
-  (let [xsrf-protection (or ((:get-state oauth2-params) request) (random-string 20))
-        auth-req (make-auth-request oauth2-params xsrf-protection)
-        target (str (:uri request) (if (:query-string request) (str "?" (:query-string request))))
-        response {:status 302
-                  :headers {"Location" (:uri auth-req)}}]
-    ((:put-target oauth2-params) ((:put-state oauth2-params) response xsrf-protection) target)))
 
 (defn- add-auth-header [req scheme param] ; Force.com
   (let [header (str scheme " " param)]

--- a/src/clj_oauth2/client.clj
+++ b/src/clj_oauth2/client.clj
@@ -9,6 +9,11 @@
   (:import [clj_oauth2 OAuth2Exception OAuth2StateMismatchException]
            [org.apache.commons.codec.binary Base64]))
 
+;; Random mixed case alphanumeric
+(defn- random-string [length]
+  (let [ascii-codes (concat (range 48 58) (range 65 91) (range 97 123))]
+    (apply str (repeatedly length #(char (rand-nth ascii-codes))))))
+
 (defn make-auth-request
   [{:keys [authorization-uri client-id redirect-uri scope access-type]}
    & [state]]
@@ -22,6 +27,15 @@
                 scope       (assoc :scope (str/join " " scope)))]
     {:uri (str (uri/make (assoc uri :query query)))
      :scope scope :state state}))
+
+(defn redirect-to-authentication-server [_ request oauth2-params]
+  "Returns a redirect to the authentication server"
+  (let [xsrf-protection (or ((:get-state oauth2-params) request) (random-string 20))
+        auth-req (make-auth-request oauth2-params xsrf-protection)
+        target (str (:uri request) (if (:query-string request) (str "?" (:query-string request))))
+        response {:status 302
+                  :headers {"Location" (:uri auth-req)}}]
+    ((:put-target oauth2-params) ((:put-state oauth2-params) response xsrf-protection) target)))
 
 (defn- add-auth-header [req scheme param] ; Force.com
   (let [header (str scheme " " param)]


### PR DESCRIPTION
- This makes it possible to decide what should happen when the request is not authenticated. For XHR requests for instance, it does not make sense to return a redirect.
