### PR TITLE
Add validation of access tokens for every request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.0
+
+* Validate access tokens in Ring middleware
+
 ## 0.4.0
 
 * Support for refresh tokens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.7.0
 
 * Validate access tokens in Ring middleware
+* Renamed :logout-callback-uri to :logout-callback-path
+* Renamed :logout-uri-client to :logout-client-path
 
 ## 0.4.0
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ clj-oauth2 wraps clj-http for accessing protected resources.
 (def force-com-oauth2
   {:authorization-uri (str login-uri "/services/oauth2/authorize")
    :access-token-uri (str login-uri "/services/oauth2/token")
-   :token-info-uri (str login.uri "services/oauth2/tokeninfo")
+   :token-validation-uri (str login.uri "services/oauth2/tokeninfo")
    :redirect-uri (System/getenv "REDIRECT_URI")
    :client-id (System/getenv "CLIENT_ID")
    :client-secret (System/getenv "CLIENT_SECRET")
@@ -66,11 +66,11 @@ clj-oauth2 wraps clj-http for accessing protected resources.
    :get-oauth2-data oauth2-ring/get-oauth2-data-from-session
    :put-oauth2-data oauth2-ring/put-oauth2-data-in-session
    ;; Client route that will trigger a log out redirect to the Authorization server
-   :logout-uri-client "logout"
+   :logout-client-path "logout"
    ;; Where to redirect the client when triggering the logout
    :logout-uri "https://auth-server.com/logout"
    ;; Redirected to by the Authorization server after a successful logout
-   :logout-callback-uri "oauthpostlogout"
+   :logout-callback-path "oauthpostlogout"
    ;; Hook to use to specify how to handle the logout callback
    :logout-callback-fn r/oauth2-logout-callback-handler
    :exclude #"^/public.*"})

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ clj-oauth2 wraps clj-http for accessing protected resources.
    :client-secret (System/getenv "CLIENT_SECRET")
    :scope ["id" "api" "refresh_token"]
    :grant-type "authorization_code"
-   :trace-messages (Boolean/valueOf (get (System/getenv) "DEBUG" "false"))
    :get-state oauth2-ring/get-state-from-session
    :put-state oauth2-ring/put-state-in-session
    :get-target oauth2-ring/get-target-from-session
@@ -118,6 +117,23 @@ If you want to redirect unauthenticated requests to the authorization server, yo
 
 Note that you should not redirect API calls, e.g calls with accept header application/json. In that case you
 may want to implement your own middleware for unathenticated requests.
+
+If you do not want to validate every access token on every request or validate them differently, you can use your
+own version of the wrap-oauth function.
+
+Example:
+```
+(defn my-custom-wrap-oauth2
+  [handler oauth2-params]
+  (-> handler
+      ;; Your own validation wrapper
+      (my-own-validate-oauth-data)
+      (wrap-add-oauth-data oauth2-params)
+      (wrap-authenticated-callback oauth2-params)
+      (wrap-logout-callback oauth2-params)
+      (wrap-logout oauth2-params)))
+```
+
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ clj-oauth2 wraps clj-http for accessing protected resources.
 (def force-com-oauth2
   {:authorization-uri (str login-uri "/services/oauth2/authorize")
    :access-token-uri (str login-uri "/services/oauth2/token")
+   :token-info-uri (str login.uri "services/oauth2/tokeninfo")
    :redirect-uri (System/getenv "REDIRECT_URI")
    :client-id (System/getenv "CLIENT_ID")
    :client-secret (System/getenv "CLIENT_SECRET")
    :scope ["id" "api" "refresh_token"]
    :grant-type "authorization_code"
-   :force-https (System/getenv "FORCE_HTTPS") ; on Heroku the app thinks it is always http
    :trace-messages (Boolean/valueOf (get (System/getenv) "DEBUG" "false"))
    :get-state oauth2-ring/get-state-from-session
    :put-state oauth2-ring/put-state-in-session

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.telenordigital.data-insights/clj-oauth2 "0.6.2"
+(defproject com.telenordigital.data-insights/clj-oauth2 "0.7.0"
   :description "clj-http and ring middlewares for OAuth 2.0"
   :url "https://github.com/comoyo/clj-oauth2"
   :dependencies [[org.clojure/clojure "1.7.0"]
@@ -7,5 +7,6 @@
                  [uri "1.1.0"]
                  [commons-codec/commons-codec "1.6"]
                  [ring "1.4.0"]]
+  :plugins [[com.jakemccrary/lein-test-refresh "0.12.0"]]
   :aot [clj-oauth2.OAuth2Exception
         clj-oauth2.OAuth2StateMismatchException])

--- a/src/clj_oauth2/client.clj
+++ b/src/clj_oauth2/client.clj
@@ -111,8 +111,9 @@
                            [:query query-param]
                            access-token))))
 
-(defn valid-auth-token? [url access-token]
+(defn valid-auth-token?
   "Validated the auth token against the validation URL"
+  [url access-token]
   (let [req (http/get url {:query-params {"access_token" access-token}
                            :throw-exceptions false})]
     (= (:status req) 200)))

--- a/src/clj_oauth2/ring.clj
+++ b/src/clj_oauth2/ring.clj
@@ -1,21 +1,22 @@
 (ns clj-oauth2.ring
   (:require [clj-oauth2.client :as oauth2]
+            [cheshire.core :as json]
             [ring.util.codec :as codec]
             [ring.util.response :as ring-response]
             [clojure.string :as string]
             [uri.core :as uri]))
 
-(defn excluded? [uri oauth2-params]
-  (let [exclusion (:exclude oauth2-params)]
+(defn excluded? [request exclusion]
+  (let [uri (:uri request)]
     (cond
-     (coll? exclusion)
-     (some = exclusion uri)
-     (string? exclusion)
-     (= exclusion uri)
-     (fn? exclusion)
-     (exclusion uri)
-     (instance? java.util.regex.Pattern exclusion)
-     (re-matches exclusion uri))))
+      (coll? exclusion)
+      (some = exclusion uri)
+      (string? exclusion)
+      (= exclusion uri)
+      (fn? exclusion)
+      (exclusion uri)
+      (instance? java.util.regex.Pattern exclusion)
+      (re-matches exclusion uri))))
 
 ;; Functions to store state, target URL, OAuth2 data in session
 ;; requires ring.middleware.session/wrap-session
@@ -56,15 +57,6 @@
    :get-oauth2-data get-oauth2-data-from-session
    :put-oauth2-data put-oauth2-data-in-session})
 
-(defn request-uri [request oauth2-params]
-  (let [scheme (if (:force-https oauth2-params) "https" (name (:scheme request)))
-        port (if (or (and (= (name (:scheme request)) "http")
-                          (not= (:server-port request) 80))
-                     (and (= (name (:scheme request)) "https")
-                          (not= (:server-port request) 443)))
-               (str ":" (:server-port request)))]
-    (str scheme "://" (:server-name request) port (:uri request))))
-
 ;; Parameter handling code shamelessly plundered from ring.middleware.
 ;; Thanks, Mark!
 (defn- keyword-syntax? [s]
@@ -72,71 +64,59 @@
 
 (defn- keyify-params [target]
   (cond
-   (map? target)
-   (into {}
-         (for [[k v] target]
-           [(if (and (string? k) (keyword-syntax? k))
-              (keyword k)
-              k)
-            (keyify-params v)]))
-   (vector? target)
-   (vec (map keyify-params target))
-   :else
-   target))
+    (map? target)
+    (into {}
+          (for [[k v] target]
+            [(if (and (string? k) (keyword-syntax? k))
+               (keyword k)
+               k)
+             (keyify-params v)]))
+    (vector? target)
+    (vec (map keyify-params target))
+    :else
+    target))
 
 (defn- assoc-param
   "Associate a key with a value. If the key already exists in the map,
 create a vector of values."
   [map key val]
   (assoc map key
-         (if-let [cur (map key)]
-           (if (vector? cur)
-             (conj cur val)
-             [cur val])
-           val)))
+             (if-let [cur (map key)]
+               (if (vector? cur)
+                 (conj cur val)
+                 [cur val])
+               val)))
 
 (defn- parse-params
   "Parse parameters from a string into a map."
   [^String param-string encoding]
   (reduce
-   (fn [param-map encoded-param]
-     (if-let [[_ key val] (re-matches #"([^=]+)=(.*)" encoded-param)]
-       (assoc-param param-map
-                    (codec/url-decode key encoding)
-                    (codec/url-decode (or val "") encoding))
-       param-map))
-   {}
-   (string/split param-string #"&")))
+    (fn [param-map encoded-param]
+      (if-let [[_ key val] (re-matches #"([^=]+)=(.*)" encoded-param)]
+        (assoc-param param-map
+                     (codec/url-decode key encoding)
+                     (codec/url-decode (or val "") encoding))
+        param-map))
+    {}
+    (string/split param-string #"&")))
 
 (defn- submap? [map1 map2]
   "Are all the key/value pairs in map1 also in map2?"
   (every?
-   (fn [item]
-     (= item (find map2 (key item))))
-   map1))
+    (fn [item]
+      (= item (find map2 (key item))))
+    map1))
 
-(defn is-callback [request oauth2-params]
-  "Returns true if this is a request to the callback URL"
-  (let [oauth2-url-vector (string/split (.toString (java.net.URI. (:redirect-uri oauth2-params))) #"\?")
-        oauth2-uri (nth oauth2-url-vector 0)
-        oauth2-url-params (nth oauth2-url-vector 1 "")
-        encoding (or (:character-encoding request) "UTF-8")]
-    (and (= oauth2-uri (request-uri request oauth2-params))
-         (submap? (keyify-params (parse-params oauth2-url-params encoding)) (:params request)))))
-
-(defn- logout? [uri oauth2-params]
-  "Checks if the uri is the same as the one configured as the client logout URI"
-  (= (:logout-uri-client oauth2-params) (.getPath (uri/make uri))))
-
-(defn- logout-client [request oauth2-params]
+(defn- logout-client
   "Logging out the client means redirecting to the authorization server's logout URI"
+  [logout-uri]
   {:status 302
-   :headers {"Location" (:logout-uri oauth2-params)}
+   :headers {"Location" logout-uri}
    :body ""})
 
-(defn- logout-callback? [uri oauth2-params]
+(defn- logout-callback? [request logout-callback-uri]
   "Checks if the URI is the same as the one configured as the logout callback URI"
-  (= (:logout-callback-uri oauth2-params) (.getPath (uri/make uri))))
+  (= (:uri request) logout-callback-uri))
 
 (defn oauth2-logout-callback-handler [req]
   "Ring handler that removes the oauth2 data from the session and redirects to the / route"
@@ -148,7 +128,7 @@ create a vector of values."
   (let [ascii-codes (concat (range 48 58) (range 65 91) (range 97 123))]
     (apply str (repeatedly length #(char (rand-nth ascii-codes))))))
 
-(defn redirect-to-authentication-server [_ request oauth2-params]
+(defn redirect-to-authentication-server [request oauth2-params]
   "Returns a redirect to the authentication server"
   (let [xsrf-protection (or ((:get-state oauth2-params) request) (random-string 20))
         auth-req (oauth2/make-auth-request oauth2-params xsrf-protection)
@@ -157,13 +137,14 @@ create a vector of values."
                   :headers {"Location" (:uri auth-req)}}]
     ((:put-target oauth2-params) ((:put-state oauth2-params) response xsrf-protection) target)))
 
-;; This Ring wrapper acts as a filter, ensuring that the user has an OAuth
-;; token for all but a set of explicitly excluded URLs. The response from
-;; oauth2/get-access-token is exposed in the request via the :oauth2 key.
-;; Requires ring.middleware.params/wrap-params and
-;; ring.middleware.keyword-params/wrap-keyword-params to have been called
-;; first.
-(defn handle-auth-callback [request oauth2-params]
+(defn handle-authenticated-callback
+  "This Ring wrapper acts as a filter, ensuring that the user has an OAuth
+  token for all but a set of explicitly excluded URLs. The response from
+  oauth2/get-access-token is exposed in the request via the :oauth2 key.
+  Requires ring.middleware.params/wrap-params and
+  ring.middleware.keyword-params/wrap-keyword-params to have been called
+  first."
+  [request oauth2-params]
   (let [response {:status 302
                   :headers {"Location" ((:get-target oauth2-params) request)}}
         oauth2-data (oauth2/get-access-token
@@ -175,15 +156,118 @@ create a vector of values."
         oauth2-data-with-userinfo (oauth2/add-userinfo oauth2-data oauth2-params)]
     ((:put-oauth2-data oauth2-params) request response oauth2-data-with-userinfo)))
 
-(defn wrap-redirect-unauthenticated [handler oauth2-params]
+(defn wrap-redirect-unauthenticated
   "Redirects to the authorization server when the request is not authenticated.
   Note that this wrapper only makes sense for requests that are initiated by a user, i.e not for XHR-requests.
   Requires the wrap-oauth2 to have been called first."
+  [handler oauth2-params]
   (fn [request]
-    (if (and (not (excluded? (:uri request) oauth2-params))
+    (if (and (not (excluded? request (:exclude oauth2-params)))
              (nil? (:oauth2 request)))
-      (redirect-to-authentication-server handler request oauth2-params)
+      (redirect-to-authentication-server request oauth2-params)
       (handler request))))
+
+(defn authenticated-callback?
+  "Checks if the request uri matches the configured authenticated callback uri"
+  [request oauth2-params]
+  (= (:uri request) (.getPath (uri/make (:redirect-uri oauth2-params)))))
+
+(defn wrap-authenticated-callback
+  "Handles authentication callbacks from the authorization server"
+  [handler oauth2-params]
+  (fn [request]
+    (if (authenticated-callback? request oauth2-params)
+      (handle-authenticated-callback request oauth2-params)
+      (handler request))))
+
+(defn wrap-logout
+  "Logs the client out of the authorization server session if the request is to the local logout URI"
+  [handler {:keys [logout-uri-client logout-uri]}]
+  (fn [request]
+    (if (= (:uri request) logout-uri-client)
+      (logout-client logout-uri)
+      (handler request))))
+
+(defn wrap-logout-callback
+  "Handles logout callbacks from the authorization server to log the user out of the local session as well"
+  [handler {:keys [logout-callback-fn logout-callback-uri]}]
+  (fn [request]
+    (if (logout-callback? request logout-callback-uri)
+      (logout-callback-fn request)
+      (handler request))))
+
+(defn update-oauth2-data [request oauth2-data]
+  (update request :oauth2 (fn [old]
+                            (-> old
+                                (assoc :access-token (:access_token oauth2-data))
+                                (assoc :refresh-token (:refresh_token oauth2-data))
+                                (assoc :params (dissoc oauth2-data :access_token :token_type))))))
+
+(defn accept-html? [request]
+  (let [accept-header (get-in request [:headers "accept"] "")]
+    (re-find (re-pattern "text/html") accept-header)))
+
+(defn refresh-token-error []
+  {:status 400
+   :headers {"Content-Type" "application/json; charset=utf-8"}
+   :body (json/generate-string {:error "Refresh token failed"
+                                :errorcode "refresh-token-failed"})})
+
+(defn failed-refresh-response
+  "Returned when refreshing the tokens fails. Dependning on the accept header, either redirect the user to
+  login again with the authentication server or return a 400 error"
+  [request oauth2-params]
+  (if (accept-html? request)
+    (redirect-to-authentication-server request oauth2-params)
+    (refresh-token-error)))
+
+(defn- refresh-oauth-data
+  "Attempts to refresh an access token using a refresh token.
+  If the refresh fails an error is returned indicating the refresh failed"
+  [handler request oauth2-params]
+  (let [[success? oauth2-update] (oauth2/refresh-access-token (:refresh-token (:oauth2 request)) oauth2-params)]
+    (if success?
+      (let [refreshed (update-oauth2-data request oauth2-update)
+            response (handler refreshed)]
+        (assoc response :oauth2 (:oauth2 refreshed)))
+      (failed-refresh-response request oauth2-params))))
+
+(defn wrap-validate-oauth-data
+  "Validates the request according to the Oauth contract
+
+  Note:
+  - requests to excluded URIs are skipped
+  - only requests with oauth2-data are validated
+
+  Validation implies the following:
+  - Checking the validity of the access token against the authorization server API
+  - Attempting to refresh the access token in the case it has expired"
+  [handler oauth2-params]
+  (fn [request]
+    (cond (excluded? request (:exclude oauth2-params))
+          (handler request)
+
+          (not (:oauth2 request))
+          (handler request)
+
+          (oauth2/valid-auth-token? (:token-info-uri oauth2-params) (:access-token (:oauth2 request)))
+          (handler request)
+
+          :else
+          (refresh-oauth-data handler request oauth2-params))))
+
+(defn wrap-add-oauth-data
+  "Adds :oauth2 key to the request"
+  [handler oauth2-params]
+  (fn [request]
+    (if (excluded? request (:exclude oauth2-params))
+      (handler request)
+      (let [oauth2-data ((:get-oauth2-data oauth2-params) request)]
+        (if (nil? oauth2-data)
+          (handler request)
+          ;; Add oauth2 data to request and response
+          (if-let [response (handler (assoc request :oauth2 oauth2-data))]
+            ((:put-oauth2-data oauth2-params) request response oauth2-data)))))))
 
 (defn wrap-oauth2
   [handler oauth2-params]
@@ -191,33 +275,16 @@ create a vector of values."
     - authorization redirects from the authorization server
     - client logout
     - logout redirects from the authorization server
+    - validating access tokens against the authorization server on every request
+    - refreshing access tokens that expire
 
     Requests are delegated to the handler directly if the uri is excluded/blacklisted or when
     the :get-oauth2-data function does not return oauth data.
 
-    If the :get-oauth2-data function returns oauth data, then it is added to the request with the :oauth2 key."
-
-  (fn [request]
-    (cond (excluded? (:uri request) oauth2-params)
-          (handler request)
-
-          ;; Redirect the client to the authorization server
-          (logout? (:uri request) oauth2-params)
-          (logout-client request oauth2-params)
-
-          ;; The authorization server redirects the client back to this URL after successful logout
-          (logout-callback? (:uri request) oauth2-params)
-          ((:logout-callback-fn oauth2-params) request)
-
-          ;; We should have an authorization code - get the access token, put
-          ;; it in the response and redirect to the originally requested URL
-          (is-callback request oauth2-params)
-          (handle-auth-callback request oauth2-params)
-
-          :else
-          (let [oauth2-data ((:get-oauth2-data oauth2-params) request)]
-            (if (nil? oauth2-data)
-              (handler request)
-              ;; We have oauth2 data - Add oauth2 to the request-map
-              (if-let [response (handler (assoc request :oauth2 oauth2-data))]
-                ((:put-oauth2-data oauth2-params) request response oauth2-data)))))))
+    If there is oauth data, then it is added to the request/response with the :oauth2 key"
+  (-> handler
+      (wrap-validate-oauth-data oauth2-params)
+      (wrap-add-oauth-data oauth2-params)
+      (wrap-authenticated-callback oauth2-params)
+      (wrap-logout-callback oauth2-params)
+      (wrap-logout oauth2-params)))

--- a/src/clj_oauth2/ring.clj
+++ b/src/clj_oauth2/ring.clj
@@ -100,8 +100,9 @@ create a vector of values."
     {}
     (string/split param-string #"&")))
 
-(defn- submap? [map1 map2]
+(defn- submap?
   "Are all the key/value pairs in map1 also in map2?"
+  [map1 map2]
   (every?
     (fn [item]
       (= item (find map2 (key item))))
@@ -114,18 +115,21 @@ create a vector of values."
    :headers {"Location" logout-uri}
    :body ""})
 
-(defn oauth2-logout-callback-handler [req]
+(defn oauth2-logout-callback-handler
   "Ring handler that removes the oauth2 data from the session and redirects to the / route"
+  [req]
   (->> (ring-response/redirect "/")
        (clear-oauth2-data-in-session req)))
 
-(defn- random-string [length]
+(defn- random-string
   "Random mixed case alphanumeric"
+  [length]
   (let [ascii-codes (concat (range 48 58) (range 65 91) (range 97 123))]
     (apply str (repeatedly length #(char (rand-nth ascii-codes))))))
 
-(defn redirect-to-authentication-server [request oauth2-params]
+(defn redirect-to-authentication-server
   "Returns a redirect to the authentication server"
+  [request oauth2-params]
   (let [xsrf-protection (or ((:get-state oauth2-params) request) (random-string 20))
         auth-req (oauth2/make-auth-request oauth2-params xsrf-protection)
         target (str (:uri request) (if (:query-string request) (str "?" (:query-string request))))
@@ -266,7 +270,6 @@ create a vector of values."
             ((:put-oauth2-data oauth2-params) request response oauth2-data)))))))
 
 (defn wrap-oauth2
-  [handler oauth2-params]
   "Handles oauth2 requests for
     - authorization redirects from the authorization server
     - client logout
@@ -278,6 +281,7 @@ create a vector of values."
     the :get-oauth2-data function does not return oauth data.
 
     If there is oauth data, then it is added to the request/response with the :oauth2 key"
+  [handler oauth2-params]
   (-> handler
       (wrap-validate-oauth-data oauth2-params)
       (wrap-add-oauth-data oauth2-params)

--- a/test/clj_oauth2/client_test.clj
+++ b/test/clj_oauth2/client_test.clj
@@ -1,161 +1,19 @@
 (ns clj-oauth2.client-test
-  (:require [cheshire.core :as json]
-            [clj-oauth2.client :as client]
-            [ring.adapter.jetty :as ring]
+  (:require [clj-oauth2.client :as client]
             [uri.core :as uri]
-            [clojure.string :as str]
-            [clojure.test :refer :all])
-  (:import [clj_oauth2 OAuth2Exception OAuth2StateMismatchException]
-           [org.apache.commons.codec.binary Base64]))
+            [clojure.test :refer :all]
+            [clj-oauth2.stub :as stub])
+  (:import [clj_oauth2 OAuth2Exception OAuth2StateMismatchException]))
 
-(def endpoint
-  {:client-id "foo"
-   :client-secret "bar"
-   :access-query-param :access_token
-   :scope ["foo" "bar"]})
-
-(def access-token
-  {:access-token "sesame"
-   :query-param :access_token
-   :token-type "bearer"
-   :expires-in 120
-   :refresh-token "new-foo"})
-
-
-(def endpoint-auth-code
-  (assoc endpoint
-    :redirect-uri "http://my.host/cb"
-    :grant-type "authorization_code"
-    :authorization-uri "http://localhost:18080/auth"
-    :access-token-uri "http://localhost:18080/token-auth-code"))
-
-(def endpoint-resource-owner
-  (assoc endpoint
-    :grant-type "password"
-    :access-token-uri "http://localhost:18080/token-password"))
-
-(def resource-owner-credentials
-  {:username "foo"
-   :password "bar"})
-
-(defn parse-auth-header [req]
-  (let [header (get-in req [:headers "authorization"] "")
-        [scheme param] (rest (re-matches #"\s*(\w+)\s+(.+)" header))]
-    (when-let [scheme (and scheme param (.toLowerCase scheme))]
-      [scheme param])))
-
-(defn parse-base64-auth-header [req]
-  (let [header (get-in req [:headers "authorization"] "")
-        [scheme param] (rest (re-matches #"\s*(\w+)\s+(.+)" header))]
-    (when-let [scheme (and scheme param (.toLowerCase scheme))]
-      [scheme (String. (Base64/decodeBase64 param) "UTF-8")])))
-
-(defn parse-basic-auth-header [req]
-  (let [[scheme param] (parse-base64-auth-header req)]
-    (and scheme param
-         (= "basic" scheme)
-         (str/split param #":" 2))))
-
-(defn handle-protected-resource [req grant & [deny]]
-  (let [query (uri/form-url-decode (:query-string req))
-        [scheme param] (parse-auth-header req)
-        bearer-token (and (= scheme "bearer") param)
-        token (or bearer-token (:access_token query))]
-    (if (= token (:access-token access-token))
-      {:status 200 :body (if (fn? grant) (grant token) grant)}
-      {:status 400 :body (or deny "nope")})))
-
-(defn client-authenticated? [req endpoint]
-  (let [body (:body req)
-        [client-id client-secret]
-        (or (parse-basic-auth-header req)
-            [(:client_id body) (:client_secret body)])]
-    (and (= client-id (:client-id endpoint))
-         (= client-secret (:client-secret endpoint)))))
-
-(defn token-response [req]
-  {:status 200
-   :headers {"content-type" (str "application/"
-                                 (if (contains? (:query-params req) :formurlenc)
-                                   "x-www-form-urlencoded"
-                                   "json")
-                                 "; charset=UTF-8")}
-   :body ((if (contains? (:query-params req) :formurlenc)
-            uri/form-url-encode
-            json/generate-string)
-          (let [{:keys [access-token
-                        token-type
-                        expires-in
-                        refresh-token]}
-                access-token]
-            {:access_token access-token
-             :token_type token-type
-             :expires_in expires-in
-             :refresh_token refresh-token}))})
-
-;; shamelessly copied from clj-http tests
-(defn handler [req]
-  
-  (let [req (assoc req :query-params (some-> req :query-string uri/form-url-decode))]
-    (condp = [(:request-method req) (:uri req)]
-      [:post "/token-auth-code"]
-      (let [{body :body :as req} (update req :body (comp uri/form-url-decode slurp))]
-        (if (and (= (:code body) "abracadabra")
-                 (= (:grant_type body) "authorization_code")
-                 (client-authenticated? req endpoint-auth-code)
-                 (= (:redirect_uri body) (:redirect-uri endpoint-auth-code)))
-          (token-response req)
-          {:status 400 :body "error=fail&error_description=invalid"}))
-      [:post "/token-password"]
-      (let [body (uri/form-url-decode (slurp (:body req)))
-            req (assoc req :body body)]
-        (if (and (= (:grant_type body) "password")
-                 (= (:username body) (:username resource-owner-credentials))
-                 (= (:password body) (:password resource-owner-credentials))
-                 (client-authenticated? req endpoint-resource-owner))
-          (token-response req)
-          {:status 400 :body "error=fail&error_description=invalid"}))
-      [:post "/token-error"]
-      {:status 400
-       :headers {"content-type" "application/json"}
-       :body (json/generate-string {:error "unauthorized_client"
-                                    :error_description "not good"})}
-      [:get "/some-resource"]
-      (handle-protected-resource req "that's gold jerry!")
-      [:get "/query-echo"]
-      (handle-protected-resource req (:query-string req))
-      [:get "/query-and-token-echo"]
-      (handle-protected-resource req
-                                 (fn [token]
-                                   (uri/form-url-encode
-                                    (assoc (:query-params req)
-                                      :access_token token))))
-      [:get "/get"]
-      (handle-protected-resource req "get")
-      [:post "/post"]
-      (handle-protected-resource req "post")
-      [:put "/put"]
-      (handle-protected-resource req "put")
-      [:delete "/delete"]
-      (handle-protected-resource req "delete")
-      [:head "/head"]
-      (handle-protected-resource req "head"))))
-
-(defn server
-  [tests]
-  (let [server (ring/run-jetty handler {:port 18080 :join? false})]
-    (tests)
-    (.stop server)))
-
-(use-fixtures :once server)
+(use-fixtures :once stub/server)
 
 (deftest grant-type-auth-code
-  (let [req (client/make-auth-request endpoint-auth-code "bazqux")
+  (let [req (client/make-auth-request stub/endpoint-auth-code "bazqux")
         uri (uri/uri->map (uri/make (:uri req)) true)]
     (testing "constructs a uri for the authorization redirect"
       (is (= (:scheme uri) "http"))
-      (is (= (:host uri) "localhost"))
-      (is (= (:port uri) 18080))
+      (is (= (:host uri) stub/host))
+      (is (= (:port uri) stub/port))
       (is (= (:path uri) "/auth"))
       (is (= (:query uri) {:response_type "code"
                            :client_id "foo"
@@ -168,88 +26,88 @@
 
   (testing "returns an access token hash-map on success"
     (is (= (:access-token (client/get-access-token
-                           endpoint-auth-code
+                           stub/endpoint-auth-code
                            {:code "abracadabra" :state "foo"}
                            {:state "foo"}))
            "sesame")))
   (testing "also works with client credentials passed in the authorization header"
-    (is (= (:access-token (client/get-access-token (assoc endpoint-auth-code
+    (is (= (:access-token (client/get-access-token (assoc stub/endpoint-auth-code
                                                           :authorization-header? true)
                                                    {:code "abracadabra" :state "foo"}
                                                    {:state "foo"}))
            "sesame")))
   (testing "also works with application/x-www-form-urlencoded responses (as produced by Facebook)"
-    (is (= (:access-token (client/get-access-token (assoc endpoint-auth-code :access-token-uri
-                                                          (str (:access-token-uri endpoint-auth-code)
+    (is (= (:access-token (client/get-access-token (assoc stub/endpoint-auth-code :access-token-uri
+                                                          (str (:access-token-uri stub/endpoint-auth-code)
                                                                "?formurlenc"))
                                                    {:code "abracadabra" :state "foo"}
                                                    {:state "foo"}))
            "sesame")))
   (testing "returns an access token when no state is given"
-    (is (= (:access-token (client/get-access-token endpoint-auth-code {:code "abracadabra"}))
+    (is (= (:access-token (client/get-access-token stub/endpoint-auth-code {:code "abracadabra"}))
            "sesame")))
   (testing "fails when state differs from expected state"
     (is (thrown? OAuth2StateMismatchException
-                 (client/get-access-token endpoint-auth-code
+                 (client/get-access-token stub/endpoint-auth-code
                                           {:code "abracadabra" :state "foo"}
                                           {:state "bar"}))))
   (testing "fails when an error response is passed in"
     (is (thrown? OAuth2Exception
-                 (client/get-access-token endpoint-auth-code
+                 (client/get-access-token stub/endpoint-auth-code
                                           {:error "invalid_client"
                                            :error_description "something went wrong"}))))
   (testing "raises on error response"
     (is (thrown? OAuth2Exception
-                 (client/get-access-token (assoc endpoint-auth-code
+                 (client/get-access-token (assoc stub/endpoint-auth-code
                                                  :access-token-uri
-                                                 "http://localhost:18080/token-error")
+                                                 (str stub/server-uri "/token-error"))
                                           {:code "abracadabra" :state "foo"}
                                           {:state "foo"})))))
 
 (deftest grant-type-resource-owner
   (testing "returns an access token hash-map on success"
-    (is (= (:access-token (client/get-access-token endpoint-resource-owner resource-owner-credentials))
+    (is (= (:access-token (client/get-access-token stub/endpoint-resource-owner stub/resource-owner-credentials))
            "sesame")))
   (testing "fails when invalid credentials are given"
     (is (thrown? OAuth2Exception
                  (client/get-access-token
-                   endpoint-resource-owner
+                   stub/endpoint-resource-owner
                    {:username "foo" :password "qux"})))))
 
 (deftest token-usage
   (testing "should grant access to protected resources"
     (is (= "that's gold jerry!"
            (:body (client/request {:method :get
-                                 :oauth2 access-token
-                                 :url "http://localhost:18080/some-resource"})))))
+                                   :oauth2 stub/access-token
+                                   :url (str stub/server-uri "/some-resource")})))))
 
   (testing "should preserve the url's query string when adding the access-token"
-    (is (= {:foo "123" (:query-param access-token) (:access-token access-token)}
+    (is (= {:foo "123" (:query-param stub/access-token) (:access-token stub/access-token)}
            (uri/form-url-decode
              (:body (client/request {:method :get
-                                   :oauth2 access-token
-                                   :query-params {:foo "123"}
-                                   :url "http://localhost:18080/query-echo"}))))))
+                                     :oauth2 stub/access-token
+                                     :query-params {:foo "123"}
+                                     :url (str stub/server-uri "/query-echo")}))))))
 
   (testing "should support passing bearer tokens through the authorization header"
-    (is (= {:foo "123" :access_token (:access-token access-token)}
+    (is (= {:foo "123" :access_token (:access-token stub/access-token)}
            (uri/form-url-decode
              (:body (client/request {:method :get
-                                   :oauth2 (dissoc access-token :query-param)
-                                   :query-params {:foo "123"}
-                                   :url "http://localhost:18080/query-and-token-echo"}))))))
+                                     :oauth2 (dissoc stub/access-token :query-param)
+                                     :query-params {:foo "123"}
+                                     :url (str stub/server-uri "/query-and-token-echo")}))))))
 
   (testing "should deny access to protected resource given an invalid access token"
     (is (= "nope"
            (:body (client/request {:method :get
-                                 :oauth2 (assoc access-token :access-token "nope")
-                                 :url "http://localhost:18080/some-resource"
-                                 :throw-exceptions false})))))
+                                   :oauth2 (assoc stub/access-token :access-token "nope")
+                                   :url (str stub/server-uri "/some-resource")
+                                   :throw-exceptions false})))))
 
   (testing "pre-defined shortcut request functions"
-    (let [req {:oauth2 access-token}]
-      (is (= "get" (:body (client/get "http://localhost:18080/get" req))))
-      (is (= "post" (:body (client/post "http://localhost:18080/post" req))))
-      (is (= "put" (:body (client/put "http://localhost:18080/put" req))))
-      (is (= "delete" (:body (client/delete "http://localhost:18080/delete" req))))
-      (is (= 200 (:status (client/head "http://localhost:18080/head" req)))))))
+    (let [req {:oauth2 stub/access-token}]
+      (is (= "get" (:body (client/get (str stub/server-uri "/get") req))))
+      (is (= "post" (:body (client/post (str stub/server-uri "/post") req))))
+      (is (= "put" (:body (client/put (str stub/server-uri "/put") req))))
+      (is (= "delete" (:body (client/delete (str stub/server-uri "/delete") req))))
+      (is (= 200 (:status (client/head (str stub/server-uri "/head") req)))))))

--- a/test/clj_oauth2/ring_test.clj
+++ b/test/clj_oauth2/ring_test.clj
@@ -26,7 +26,7 @@
   (let [oauth2-config {:get-oauth2-data r/get-oauth2-data-from-session
                        :put-oauth2-data r/put-oauth2-data-in-session
                        :redirect-uri "not-used"
-                       :token-info-uri (str stub/server-uri "/tokeninfo")}
+                       :token-validation-uri (str stub/server-uri "/tokeninfo")}
         wrapper-fn (r/wrap-oauth2 (fn [req] ok-response)
                                   oauth2-config)]
     (is (= (wrapper-fn {:scheme "https"
@@ -38,7 +38,7 @@
   (let [oauth2-config {:get-oauth2-data r/get-oauth2-data-from-session
                        :put-oauth2-data r/put-oauth2-data-in-session
                        :redirect-uri "not-used"
-                       :token-info-uri (str stub/server-uri "/tokeninfo")
+                       :token-validation-uri (str stub/server-uri "/tokeninfo")
                        :access-token-uri (str stub/server-uri "/token-refresh")}
         wrapper-fn (r/wrap-oauth2 (fn [req] ok-response)
                                   oauth2-config)
@@ -62,7 +62,7 @@
                          :get-target r/get-target-from-session
                          :put-target r/put-target-in-session
                          :redirect-uri "somewhere"
-                         :token-info-uri (str stub/server-uri "/tokeninfo")
+                         :token-validation-uri (str stub/server-uri "/tokeninfo")
                          :access-token-uri (str stub/server-uri "/token-refresh-always-fails")}
           wrapper-fn (r/wrap-oauth2 (fn [req] ok-response)
                                     oauth2-config)
@@ -77,7 +77,7 @@
     (let [oauth2-config {:get-oauth2-data r/get-oauth2-data-from-session
                          :put-oauth2-data r/put-oauth2-data-in-session
                          :redirect-uri "not-used"
-                         :token-info-uri (str stub/server-uri "/tokeninfo")
+                         :token-validation-uri (str stub/server-uri "/tokeninfo")
                          :access-token-uri (str stub/server-uri "/token-refresh-always-fails")}
           wrapper-fn (r/wrap-oauth2 (fn [req] ok-response)
                                     oauth2-config)
@@ -114,8 +114,8 @@
                          :put-target r/put-target-in-session
                          :redirect-uri "not-used"
                          :logout-uri "https://auth-server.com/logout"
-                         :logout-uri-client "logout"
-                         :logout-callback-uri "not-used-in-test"}
+                         :logout-client-path "logout"
+                         :logout-callback-path "not-used-in-test"}
           wrapper-fn (r/wrap-oauth2 (fn [req] unused-response)
                                     oauth2-config)
           response (wrapper-fn {:scheme "https"
@@ -134,8 +134,8 @@
                          :put-target r/put-target-in-session
                          :redirect-uri "not-used"
                          :logout-uri "https://auth-server.com/logout"
-                         :logout-uri-client "logout"
-                         :logout-callback-uri "oauthpostlogout"
+                         :logout-client-path "logout"
+                         :logout-callback-path "oauthpostlogout"
                          :logout-callback-fn r/oauth2-logout-callback-handler}
           wrapper-fn (r/wrap-oauth2 (fn [req] unused-response)
                                     oauth2-config)

--- a/test/clj_oauth2/ring_test.clj
+++ b/test/clj_oauth2/ring_test.clj
@@ -1,6 +1,11 @@
 (ns clj_oauth2.ring-test
   (:require [clojure.test :refer :all]
-            [clj-oauth2.ring :as r]))
+            [clj-oauth2.ring :as r]
+            [clojure.pprint :refer [pprint]]
+            [clj-oauth2.stub :as stub]))
+
+;; Start an authentication server stub to run the tests against
+(use-fixtures :once stub/server)
 
 ;; Stubbed out response that makes it possible verify that a handler was invoked by the wrapper
 (def ok-response {:status 200
@@ -12,19 +17,77 @@
                       :headers {}})
 
 (deftest can-exclude-handlers
-  (let [wrapper-fn (r/wrap-oauth2 (fn [req] ok-response) {:exclude "excluded"})]
-    (is (= (wrapper-fn {:uri "excluded"}) ok-response))))
+  (let [wrapper-fn (r/wrap-oauth2 (fn [req] ok-response) {:exclude "excluded"
+                                                          :redirect-uri "notused"})]
+    (is (= (wrapper-fn {:uri "excluded"
+                        :scheme "http"}) ok-response))))
 
 (deftest existing-oauth-data-are-returned-in-response
-    (let [oauth2-config {:get-oauth2-data r/get-oauth2-data-from-session
+  (let [oauth2-config {:get-oauth2-data r/get-oauth2-data-from-session
                        :put-oauth2-data r/put-oauth2-data-in-session
-                       :redirect-uri "not-used"}
+                       :redirect-uri "not-used"
+                       :token-info-uri (str stub/server-uri "/tokeninfo")}
         wrapper-fn (r/wrap-oauth2 (fn [req] ok-response)
                                   oauth2-config)]
     (is (= (wrapper-fn {:scheme "https"
                         :uri "whatever"
-                        :session {:oauth2 {:sample-data "data!"}}})
-           (merge ok-response {:session {:oauth2 {:sample-data "data!"}}})))))
+                        :session {:oauth2 {:access-token stub/access-token-valid}}})
+           (merge ok-response {:session {:oauth2 {:access-token stub/access-token-valid}}})))))
+
+(deftest invalid-authentication-tokens-are-refreshed
+  (let [oauth2-config {:get-oauth2-data r/get-oauth2-data-from-session
+                       :put-oauth2-data r/put-oauth2-data-in-session
+                       :redirect-uri "not-used"
+                       :token-info-uri (str stub/server-uri "/tokeninfo")
+                       :access-token-uri (str stub/server-uri "/token-refresh")}
+        wrapper-fn (r/wrap-oauth2 (fn [req] ok-response)
+                                  oauth2-config)
+        response (wrapper-fn {:scheme "https"
+                              :uri "whatever"
+                              :session {:oauth2 {:access-token stub/access-token-invalid}}})]
+    (is (= (:status response) 200))
+    (is (= (:body response) "ok"))
+    (is (= (get-in response [:session :oauth2])
+           {:access-token "sesame"
+            :refresh-token "new-foo"
+            :params {:expires_in 120
+                     :refresh_token "new-foo"}}))))
+
+(deftest failure-to-refresh-tokens-fails-the-request
+  (testing "redirect html requests"
+    (let [oauth2-config {:get-oauth2-data r/get-oauth2-data-from-session
+                         :put-oauth2-data r/put-oauth2-data-in-session
+                         :get-state r/get-state-from-session
+                         :put-state r/put-state-in-session
+                         :get-target r/get-target-from-session
+                         :put-target r/put-target-in-session
+                         :redirect-uri "somewhere"
+                         :token-info-uri (str stub/server-uri "/tokeninfo")
+                         :access-token-uri (str stub/server-uri "/token-refresh-always-fails")}
+          wrapper-fn (r/wrap-oauth2 (fn [req] ok-response)
+                                    oauth2-config)
+          response (wrapper-fn {:scheme "https"
+                                :uri "whatever"
+                                :headers {"accept" "text/html"}
+                                :session {:oauth2 {:access-token stub/access-token-invalid}}})]
+      (is (= (:status response) 302))
+      (is (get-in response [:headers "Location"]))))
+
+  (testing "redirect non-html requests"
+    (let [oauth2-config {:get-oauth2-data r/get-oauth2-data-from-session
+                         :put-oauth2-data r/put-oauth2-data-in-session
+                         :redirect-uri "not-used"
+                         :token-info-uri (str stub/server-uri "/tokeninfo")
+                         :access-token-uri (str stub/server-uri "/token-refresh-always-fails")}
+          wrapper-fn (r/wrap-oauth2 (fn [req] ok-response)
+                                    oauth2-config)
+          response (wrapper-fn {:scheme "https"
+                                :uri "whatever"
+                                :headers {:accept "application/json"}
+                                :session {:oauth2 {:access-token stub/access-token-invalid}}})]
+      (is (= (:status response) 400))
+      (is (= (:headers response) {"Content-Type" "application/json; charset=utf-8"}))
+      (is (= (:body response) "{\"error\":\"Refresh token failed\",\"errorcode\":\"refresh-token-failed\"}")))))
 
 (deftest missing-oauth-data-results-in-fall-through
   (let [oauth2-config {:get-oauth2-data r/get-oauth2-data-from-session
@@ -94,7 +157,7 @@
                          :put-target r/put-target-in-session
                          :redirect-uri "somewhere"}
           wrapper-fn (r/wrap-redirect-unauthenticated (fn [_] unused-response)
-                                                             oauth2-config)
+                                                      oauth2-config)
           response (wrapper-fn {:scheme "https"
                                 :uri "whatever"
                                 :session {}})]
@@ -110,11 +173,12 @@
                          :put-target r/put-target-in-session
                          :redirect-uri "somewhere"}
           wrapper-fn (r/wrap-redirect-unauthenticated (fn [_] ok-response)
-                                                             oauth2-config)
+                                                      oauth2-config)
           response (wrapper-fn {:scheme "https"
                                 :uri "whatever"
                                 :oauth2 {:data "data"}})]
       (is (= (:status response) 200))))
+
   (testing "excluded url results in fall through"
     (let [oauth2-config {:get-oauth2-data r/get-oauth2-data-from-session
                          :put-oauth2-data r/put-oauth2-data-in-session

--- a/test/clj_oauth2/stub.clj
+++ b/test/clj_oauth2/stub.clj
@@ -1,0 +1,167 @@
+(ns clj-oauth2.stub
+  (:require [uri.core :as uri]
+            [cheshire.core :as json]
+            [clojure.string :as str]
+            [ring.adapter.jetty :as ring])
+  (:import [org.apache.commons.codec.binary Base64]))
+
+(def port 18080)
+(def host "localhost")
+(def server-uri (str "http://" host ":" port))
+
+(def access-token-valid "always valid")
+(def access-token-invalid "always invalid")
+
+(def access-token
+  {:access-token "sesame"
+   :query-param :access_token
+   :token-type "bearer"
+   :expires-in 120
+   :refresh-token "new-foo"})
+
+(def endpoint
+  {:client-id "foo"
+   :client-secret "bar"
+   :access-query-param :access_token
+   :scope ["foo" "bar"]})
+
+(def endpoint-auth-code
+  (assoc endpoint
+    :redirect-uri "http://my.host/cb"
+    :grant-type "authorization_code"
+    :authorization-uri "http://localhost:18080/auth"
+    :access-token-uri "http://localhost:18080/token-auth-code"))
+
+(def endpoint-resource-owner
+  (assoc endpoint
+    :grant-type "password"
+    :access-token-uri "http://localhost:18080/token-password"))
+
+(def resource-owner-credentials
+  {:username "foo"
+   :password "bar"})
+
+(defn parse-auth-header [req]
+  (let [header (get-in req [:headers "authorization"] "")
+        [scheme param] (rest (re-matches #"\s*(\w+)\s+(.+)" header))]
+    (when-let [scheme (and scheme param (.toLowerCase scheme))]
+      [scheme param])))
+
+(defn parse-base64-auth-header [req]
+  (let [header (get-in req [:headers "authorization"] "")
+        [scheme param] (rest (re-matches #"\s*(\w+)\s+(.+)" header))]
+    (when-let [scheme (and scheme param (.toLowerCase scheme))]
+      [scheme (String. (Base64/decodeBase64 param) "UTF-8")])))
+
+(defn parse-basic-auth-header [req]
+  (let [[scheme param] (parse-base64-auth-header req)]
+    (and scheme param
+         (= "basic" scheme)
+         (str/split param #":" 2))))
+
+
+(defn- handle-protected-resource [req grant & [deny]]
+  (let [query (uri/form-url-decode (:query-string req))
+        [scheme param] (parse-auth-header req)
+        bearer-token (and (= scheme "bearer") param)
+        token (or bearer-token (:access_token query))]
+    (if (= token (:access-token access-token))
+      {:status 200 :body (if (fn? grant) (grant token) grant)}
+      {:status 400 :body (or deny "nope")})))
+
+(defn- client-authenticated? [req endpoint]
+  (let [body (:body req)
+        [client-id client-secret]
+        (or (parse-basic-auth-header req)
+            [(:client_id body) (:client_secret body)])]
+    (and (= client-id (:client-id endpoint))
+         (= client-secret (:client-secret endpoint)))))
+
+(defn- token-response [req access-token]
+  {:status 200
+   :headers {"content-type" (str "application/"
+                                 (if (contains? (:query-params req) :formurlenc)
+                                   "x-www-form-urlencoded"
+                                   "json")
+                                 "; charset=UTF-8")}
+   :body ((if (contains? (:query-params req) :formurlenc)
+            uri/form-url-encode
+            json/generate-string)
+           (let [{:keys [access-token
+                         token-type
+                         expires-in
+                         refresh-token]}
+                 access-token]
+             {:access_token access-token
+              :token_type token-type
+              :expires_in expires-in
+              :refresh_token refresh-token}))})
+
+;; shamelessly copied from clj-http tests
+(defn handler [req]
+
+  (let [req (assoc req :query-params (some-> req :query-string uri/form-url-decode))]
+    (condp = [(:request-method req) (:uri req)]
+      [:post "/token-auth-code"]
+      (let [{body :body :as req} (update req :body (comp uri/form-url-decode slurp))]
+        (if (and (= (:code body) "abracadabra")
+                 (= (:grant_type body) "authorization_code")
+                 (client-authenticated? req endpoint-auth-code)
+                 (= (:redirect_uri body) (:redirect-uri endpoint-auth-code)))
+          (token-response req access-token)
+          {:status 400 :body "error=fail&error_description=invalid"}))
+      [:post "/token-password"]
+      (let [body (uri/form-url-decode (slurp (:body req)))
+            req (assoc req :body body)]
+        (if (and (= (:grant_type body) "password")
+                 (= (:username body) (:username resource-owner-credentials))
+                 (= (:password body) (:password resource-owner-credentials))
+                 (client-authenticated? req endpoint-resource-owner))
+          (token-response req access-token)
+          {:status 400 :body "error=fail&error_description=invalid"}))
+      [:post "/token-refresh"]
+      (token-response req access-token)
+      [:post "/token-refresh-always-fails"]
+      {:status 400 :body (json/generate-string {:error "fail"
+                                                :error_description "Refresh token expired"})}
+      [:get "/tokeninfo"]
+      (if (= (get-in req [:query-params :access_token]) access-token-valid)
+        {:status 200
+         :body (json/generate-string {:client-id (:client-id endpoint)
+                                      :scope ["foo" "bar"]
+                                      :userid "foo"
+                                      :ttl "3447"})}
+        {:status 400
+         :body (json/generate-string {:error "invalid_token"
+                                      :error_description "Token does not exist, or it has expired"})})
+      [:post "/token-error"]
+      {:status 400
+       :headers {"content-type" "application/json"}
+       :body (json/generate-string {:error "unauthorized_client"
+                                    :error_description "not good"})}
+      [:get "/some-resource"]
+      (handle-protected-resource req "that's gold jerry!")
+      [:get "/query-echo"]
+      (handle-protected-resource req (:query-string req))
+      [:get "/query-and-token-echo"]
+      (handle-protected-resource req
+                                 (fn [token]
+                                   (uri/form-url-encode
+                                     (assoc (:query-params req)
+                                       :access_token token))))
+      [:get "/get"]
+      (handle-protected-resource req "get")
+      [:post "/post"]
+      (handle-protected-resource req "post")
+      [:put "/put"]
+      (handle-protected-resource req "put")
+      [:delete "/delete"]
+      (handle-protected-resource req "delete")
+      [:head "/head"]
+      (handle-protected-resource req "head"))))
+
+(defn server
+  [tests]
+  (let [server (ring/run-jetty handler {:port 18080 :join? false})]
+    (tests)
+    (.stop server)))


### PR DESCRIPTION
- if access token fails to validate, an attempt is made to retrieve new tokens using the refresh-token
- fixed the refresh-access-token function
- refactored the code to a more composable design
- refactored out the stubbed server into a separate test namespace in order to reuse it in ring_test
