### PR TITLE
Do not update the session when refresh token fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1
+
+* Do not update session when refresh token fails
+
 ## 0.7.0
 
 * Validate access tokens in Ring middleware

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.telenordigital.data-insights/clj-oauth2 "0.7.0"
+(defproject com.telenordigital.data-insights/clj-oauth2 "0.7.1"
   :description "clj-http and ring middlewares for OAuth 2.0"
   :url "https://github.com/comoyo/clj-oauth2"
   :dependencies [[org.clojure/clojure "1.7.0"]

--- a/test/clj_oauth2/ring_test.clj
+++ b/test/clj_oauth2/ring_test.clj
@@ -87,7 +87,9 @@
                                 :session {:oauth2 {:access-token stub/access-token-invalid}}})]
       (is (= (:status response) 400))
       (is (= (:headers response) {"Content-Type" "application/json; charset=utf-8"}))
-      (is (= (:body response) "{\"error\":\"Refresh token failed\",\"errorcode\":\"refresh-token-failed\"}")))))
+      (is (= (:body response) "{\"error\":\"Refresh token failed\",\"errorcode\":\"refresh-token-failed\"}"))
+      ;; We don't want the cookie to be updated on failures, hence the session must be blank
+      (is (not (:session response))))))
 
 (deftest missing-oauth-data-results-in-fall-through
   (let [oauth2-config {:get-oauth2-data r/get-oauth2-data-from-session


### PR DESCRIPTION
This avoids the concurrency issue when that occurs when the backend gets multiple requests from the same client while token refresh occurs.
